### PR TITLE
Run local jenkins tests automatically on commit

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -3,5 +3,6 @@ jenkins:
     file: docker-compose-template.yml
     service: jenkins
   volumes:
+    - ../:/var/dev_repo:ro # Clone this RO so as to guarentee we never touch dev files.
     - ./jenkins/jenkins_home:/var/jenkins_home 
     - /var/run/docker.sock:/var/run/docker.sock

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -3,6 +3,6 @@ jenkins:
     file: docker-compose-template.yml
     service: jenkins
   volumes:
-    - ../:/var/dev_repo:ro # Clone this RO so as to guarentee we never touch dev files.
+    - ../:/var/dev_repo:ro # Clone this RO so as to guarantee we never touch dev files.
     - ./jenkins/jenkins_home:/var/jenkins_home 
     - /var/run/docker.sock:/var/run/docker.sock

--- a/ci/jenkins/Dockerfile
+++ b/ci/jenkins/Dockerfile
@@ -28,4 +28,6 @@ RUN /usr/local/bin/plugins.sh /usr/share/jenkins/ref/plugins.txt
 COPY ./jenkins_home /var/jenkins_home
 
 # Declare environment variables
-ENV DOCKER_HOST=unix:///var/run/docker.sock
+ENV \
+    DOCKER_HOST=unix:///var/run/docker.sock \
+    DEV_REPO=/var/dev_repo

--- a/ci/jenkins/jenkins_home/jobs/integration_test/config.xml
+++ b/ci/jenkins/jenkins_home/jobs/integration_test/config.xml
@@ -30,12 +30,6 @@
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>true</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>true</blockBuildWhenUpstreamBuilding>
-  <triggers>
-    <hudson.triggers.SCMTrigger>
-      <spec>* * * * *</spec>
-      <ignorePostCommitHooks>false</ignorePostCommitHooks>
-    </hudson.triggers.SCMTrigger>
-  </triggers>
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>

--- a/ci/jenkins/jenkins_home/jobs/integration_test/config.xml
+++ b/ci/jenkins/jenkins_home/jobs/integration_test/config.xml
@@ -14,7 +14,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>https://github.com/rgardler/AzureDevTestDeploy</url>
+        <url>${DEV_REPO}</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/ci/jenkins/jenkins_home/jobs/load_test/config.xml
+++ b/ci/jenkins/jenkins_home/jobs/load_test/config.xml
@@ -8,7 +8,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>https://github.com/rgardler/AzureDevTestDeploy</url>
+        <url>${DEV_REPO}</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/script/setup_git_commit_hook.sh
+++ b/script/setup_git_commit_hook.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+HOOK="${SCRIPTDIR}/../.git/hooks/post-commit"
+JENKINS_DOCKER_INSTANCE="localhost:8081"
+TEST_NAME="integration_test"
+TEST_RUN_DELAY="0sec"
+
+echo "curl http://${JENKINS_DOCKER_INSTANCE}/job/${TEST_NAME}/build?delay=${TEST_RUN_DELAY}" > $HOOK
+chmod +x $HOOK

--- a/script/setup_git_commit_hook.sh
+++ b/script/setup_git_commit_hook.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# This script configures the local git repo to automatically run jenkins tests after each commit.
+# The post-commit hook will not cause the commit to fail if jenkins cannot be reached (if the container is not running)
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 HOOK="${SCRIPTDIR}/../.git/hooks/post-commit"


### PR DESCRIPTION
This pull request modifies the jenkins container to pull changes from the local git repository. The repository to pull from can also be overriden by setting the `GIT_REPO` environment variable within the jenkins container. This can be used to use a github or other repo.

To setup your local repository to do this run `script/setup_git_commit_hook.sh`
